### PR TITLE
신사업 발굴 에이전트: 진입 위저드 웹페이지(index.html)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>신사업 발굴 에이전트</title>
+<meta name="robots" content="noindex, nofollow" />
+<style>
+  :root{
+    --navy:#0f3a5f; --navy2:#16527f; --teal:#14b8a6; --amber:#f59e0b;
+    --slate:#475569; --line:#e2e8f0; --bg:#f6f8fb; --card:#fff; --ink:#0f172a; --muted:#64748b;
+    --shadow:0 1px 3px rgba(15,23,42,.08),0 10px 30px rgba(15,23,42,.07);
+  }
+  *{box-sizing:border-box}
+  body{margin:0; background:var(--bg); color:var(--ink); line-height:1.6;
+    font-family:-apple-system,BlinkMacSystemFont,"Apple SD Gothic Neo","Pretendard","Malgun Gothic",sans-serif}
+  a{color:var(--navy2)}
+  .wrap{max-width:860px; margin:0 auto; padding:0 20px}
+
+  header.hero{background:linear-gradient(135deg,var(--navy),var(--navy2)); color:#fff; padding:40px 0 32px}
+  .hero .tag{display:inline-block; font-size:12px; letter-spacing:.5px; background:rgba(255,255,255,.15);
+    padding:4px 11px; border-radius:999px; margin-bottom:12px}
+  .hero h1{margin:0 0 8px; font-size:30px; font-weight:800; letter-spacing:-.5px}
+  .hero p{margin:0; color:#cfe2f1; font-size:15px; max-width:640px}
+
+  main{padding:30px 0 60px}
+  .progress{display:flex; gap:8px; margin-bottom:22px}
+  .progress .dot{flex:1; height:6px; border-radius:6px; background:var(--line); transition:.3s}
+  .progress .dot.on{background:var(--teal)}
+
+  .card{background:var(--card); border:1px solid var(--line); border-radius:16px; box-shadow:var(--shadow); padding:26px}
+  .step{display:none} .step.active{display:block; animation:fade .25s ease}
+  @keyframes fade{from{opacity:0; transform:translateY(6px)}to{opacity:1; transform:none}}
+  .step .stepno{font-size:12px; font-weight:800; color:var(--teal); letter-spacing:1px}
+  .step h2{margin:4px 0 4px; font-size:21px; font-weight:800}
+  .step .desc{color:var(--muted); font-size:14px; margin:0 0 20px}
+
+  label.fl{display:block; font-size:13px; font-weight:700; color:var(--slate); margin:18px 0 8px}
+  input[type=text]{width:100%; padding:13px 15px; font-size:15px; border:1.5px solid var(--line); border-radius:11px; outline:none; font-family:inherit}
+  input[type=text]:focus{border-color:var(--teal); box-shadow:0 0 0 3px rgba(20,184,166,.12)}
+
+  .chips{display:flex; flex-wrap:wrap; gap:8px}
+  .chip{font-size:13px; font-weight:600; padding:8px 14px; border-radius:999px; border:1.5px solid var(--line);
+    background:#fff; color:var(--slate); cursor:pointer; user-select:none; transition:.15s}
+  .chip:hover{border-color:var(--teal)}
+  .chip.sel{background:var(--navy); border-color:var(--navy); color:#fff}
+  .chip.ex{border-style:dashed; color:var(--navy2)}
+
+  .seg{display:inline-flex; border:1.5px solid var(--line); border-radius:11px; overflow:hidden}
+  .seg button{border:none; background:#fff; padding:11px 20px; font-size:14px; font-weight:600; color:var(--slate); cursor:pointer}
+  .seg button.on{background:var(--navy); color:#fff}
+
+  .tags{display:flex; flex-wrap:wrap; gap:8px; margin-top:10px}
+  .tag{display:inline-flex; align-items:center; gap:7px; background:#eef6f5; color:#0f766e; border:1px solid #99f6e4;
+    font-size:13px; font-weight:600; padding:6px 10px; border-radius:9px}
+  .tag b{cursor:pointer; color:#0f766e; opacity:.6}
+  .tag b:hover{opacity:1}
+  .tagrow{display:flex; gap:8px; margin-top:8px}
+  .tagrow input{flex:1}
+  .addbtn{border:1.5px solid var(--navy); background:var(--navy); color:#fff; border-radius:11px; padding:0 18px; font-weight:700; cursor:pointer}
+
+  .nav{display:flex; justify-content:space-between; margin-top:26px; gap:12px}
+  .btn{font-size:15px; font-weight:700; border-radius:12px; padding:13px 24px; cursor:pointer; border:1.5px solid var(--line); background:#fff; color:var(--slate)}
+  .btn:hover{background:#f1f5f9}
+  .btn.primary{background:var(--navy); border-color:var(--navy); color:#fff}
+  .btn.primary:hover{background:#0c3050}
+  .btn.go{background:var(--teal); border-color:var(--teal); color:#fff}
+  .btn:disabled{opacity:.45; cursor:not-allowed}
+
+  /* result */
+  .summary{display:grid; grid-template-columns:1fr 1fr; gap:10px; margin:6px 0 18px}
+  @media(max-width:640px){.summary{grid-template-columns:1fr}}
+  .summary .k{background:#f8fafc; border:1px solid var(--line); border-radius:10px; padding:10px 13px}
+  .summary .k .l{font-size:11px; color:var(--muted); font-weight:700}
+  .summary .k .v{font-size:14px; font-weight:600; margin-top:2px}
+  .codebox{position:relative; background:#0f1f2e; border-radius:12px; padding:16px; margin-top:8px}
+  .codebox pre{margin:0; color:#d6e2ee; font-size:12.5px; line-height:1.55; white-space:pre-wrap; word-break:break-all;
+    font-family:"SF Mono",ui-monospace,Menlo,Consolas,monospace; max-height:260px; overflow:auto}
+  .copy{position:absolute; top:10px; right:10px; font-size:12px; font-weight:700; border:none; background:#1e3851; color:#cbd5e1; padding:6px 11px; border-radius:8px; cursor:pointer}
+  .copy:hover{background:#27496b; color:#fff}
+  .demo{display:flex; align-items:center; gap:14px; background:#ecfdf5; border:1px solid #a7f3d0; border-radius:12px; padding:14px 16px; margin-top:16px}
+  .demo .t{flex:1; font-size:14px; color:#065f46}
+  .hint{font-size:12.5px; color:var(--muted); margin-top:8px}
+  .pipeline{display:flex; gap:8px; flex-wrap:wrap; margin:14px 0 2px}
+  .pipeline span{font-size:12px; font-weight:700; background:#eef2f7; color:var(--slate); padding:6px 11px; border-radius:8px}
+  .pipeline span.s{background:#e0f2fe; color:#075985}
+  footer{color:var(--muted); font-size:12px; text-align:center; padding:24px 0 50px}
+</style>
+</head>
+<body>
+<header class="hero">
+  <div class="wrap">
+    <span class="tag">신사업추진파트 · 발굴 에이전트</span>
+    <h1>신사업 발굴 에이전트</h1>
+    <p>사업 영역을 지정하고 몇 가지를 선택하면, 시장·경쟁·규제를 병렬 리서치해 <b>진입 초기의견 인터랙티브 리포트</b>를 만들어 드립니다.</p>
+  </div>
+</header>
+
+<main>
+<div class="wrap">
+  <div class="progress"><div class="dot on" data-d="0"></div><div class="dot" data-d="1"></div><div class="dot" data-d="2"></div></div>
+
+  <div class="card">
+    <!-- STEP 1 -->
+    <section class="step active" id="s0">
+      <div class="stepno">STEP 1 / 3</div>
+      <h2>어떤 신사업 영역을 검토할까요?</h2>
+      <p class="desc">산업·제품·서비스 영역을 자유롭게 입력하세요. 생명보험사 관점에서 진입성을 분석합니다.</p>
+      <label class="fl">신사업 영역</label>
+      <input type="text" id="area" placeholder="예) AI 웰니스로봇" autocomplete="off" />
+      <label class="fl" style="margin-top:20px">빠른 예시</label>
+      <div class="chips" id="examples"></div>
+      <div class="nav"><span></span><button class="btn primary" id="next0" disabled>다음 →</button></div>
+    </section>
+
+    <!-- STEP 2 -->
+    <section class="step" id="s1">
+      <div class="stepno">STEP 2 / 3</div>
+      <h2>분석 방향을 좁혀볼까요?</h2>
+      <p class="desc">전략 관점·벤치마크·지역을 지정하면 리서치 초점이 또렷해집니다. (선택 사항 — 건너뛰어도 됩니다)</p>
+
+      <label class="fl">① 전략 관점 (렌즈) <span style="font-weight:400;color:var(--muted)">· 복수 선택</span></label>
+      <div class="chips" id="lenses"></div>
+
+      <label class="fl">② 벤치마크 기업 <span style="font-weight:400;color:var(--muted)">· 비교·참고할 기업</span></label>
+      <div class="tagrow"><input type="text" id="benchInput" placeholder="기업명 입력 후 Enter (예: SK인텔릭스)" autocomplete="off" /><button class="addbtn" id="benchAdd">추가</button></div>
+      <div class="tags" id="benchTags"></div>
+      <div class="chips" id="benchSug" style="margin-top:10px"></div>
+
+      <label class="fl">③ 지역 범위</label>
+      <div class="seg" id="region">
+        <button data-v="국내 중심" class="on">국내 중심</button>
+        <button data-v="글로벌 포함">글로벌 포함</button>
+      </div>
+
+      <div class="nav"><button class="btn" id="back1">← 이전</button><button class="btn primary" id="next1">다음 →</button></div>
+    </section>
+
+    <!-- STEP 3 -->
+    <section class="step" id="s2">
+      <div class="stepno">STEP 3 / 3</div>
+      <h2>리서치 실행 준비 완료</h2>
+      <p class="desc">아래 설정으로 발굴 에이전트가 <b>시장 · 경쟁 · 규제</b>를 병렬 리서치한 뒤 진입의견을 종합합니다.</p>
+
+      <div class="pipeline">
+        <span class="s">① 시장조사</span><span class="s">② 경쟁환경</span><span class="s">③ 규제</span><span>→</span><span class="s">④ 진입 초기의견</span><span>→</span><span>인터랙티브 리포트</span>
+      </div>
+
+      <div class="summary" id="summary"></div>
+
+      <label class="fl">리서치 설정 + 실행 프롬프트 <span style="font-weight:400;color:var(--muted)">· Claude Code 발굴 에이전트에 붙여넣어 실행</span></label>
+      <div class="codebox"><button class="copy" id="copyPrompt">복사</button><pre id="prompt"></pre></div>
+      <div class="hint">이 설정을 Claude Code 에이전트에 전달하면 리서치를 수행하고 <code>reports/&lt;영역&gt;.html</code> 인터랙티브 리포트를 생성·게시합니다. (정적 위저드 — 실제 리서치 실행은 에이전트가 담당)</div>
+
+      <div class="demo" id="demoBox" style="display:none">
+        <div class="t">✅ 이 영역은 <b>이미 생성된 리포트</b>가 있습니다. 결과 UX를 바로 확인해 보세요.</div>
+        <a class="btn go" id="demoLink" href="#">데모 리포트 열기 ↗</a>
+      </div>
+
+      <div class="nav"><button class="btn" id="back2">← 이전</button><button class="btn primary" id="restart">새 영역으로 다시</button></div>
+    </section>
+  </div>
+
+  <footer>신사업 발굴 에이전트 · 정적 위저드 (Phase 1) · 완전 자동 생성(백엔드)은 Phase 2 이후</footer>
+</div>
+</main>
+
+<script>
+const $=s=>document.querySelector(s), $$=s=>[...document.querySelectorAll(s)];
+const state={ area:"", lenses:new Set(), benchmarks:[], region:"국내 중심" };
+
+const EXAMPLES=["AI 웰니스로봇","시니어 요양·시니어케어","마이데이터·금융플랫폼","디지털 헬스케어","반려동물(펫) 보험·헬스케어","임베디드 보험"];
+const LENSES=["건강증진형 보험 연계","시니어·요양 사업","헬스케어 데이터 활용","신채널·플랫폼","투자·M&A(지분)","ESG·공적연계"];
+const BENCH_SUGGEST=["SK인텔릭스","삼성전자","LG전자","신한라이프","KT","ElliQ(미국)"];
+
+// 이미 생성된 리포트 레지스트리
+const REGISTRY=[{ keywords:["웰니스","wellness","로봇"], url:"reports/ai-wellness-robot.html", title:"AI 웰니스로봇" }];
+function findReport(area){const a=(area||"").toLowerCase(); return REGISTRY.find(r=>r.keywords.some(k=>a.includes(k.toLowerCase())));}
+
+// STEP 1
+const ex=$("#examples");
+EXAMPLES.forEach(e=>{const c=document.createElement("div");c.className="chip ex";c.textContent=e;
+  c.onclick=()=>{$("#area").value=e; state.area=e; $("#next0").disabled=false;}; ex.appendChild(c);});
+$("#area").addEventListener("input",e=>{state.area=e.target.value.trim(); $("#next0").disabled=!state.area;});
+
+// STEP 2 lenses
+const lc=$("#lenses");
+LENSES.forEach(l=>{const c=document.createElement("div");c.className="chip";c.textContent=l;
+  c.onclick=()=>{ if(state.lenses.has(l)){state.lenses.delete(l);c.classList.remove("sel");}
+    else{state.lenses.add(l);c.classList.add("sel");}}; lc.appendChild(c);});
+// benchmarks
+function renderTags(){const t=$("#benchTags");t.innerHTML="";
+  state.benchmarks.forEach((b,i)=>{const s=document.createElement("span");s.className="tag";
+    s.innerHTML=b+" <b>✕</b>"; s.querySelector("b").onclick=()=>{state.benchmarks.splice(i,1);renderTags();}; t.appendChild(s);});}
+function addBench(v){v=(v||"").trim(); if(v&&!state.benchmarks.includes(v)){state.benchmarks.push(v);renderTags();}}
+$("#benchAdd").onclick=()=>{addBench($("#benchInput").value);$("#benchInput").value="";};
+$("#benchInput").addEventListener("keydown",e=>{if(e.key==="Enter"){e.preventDefault();addBench(e.target.value);e.target.value="";}});
+const bs=$("#benchSug");
+BENCH_SUGGEST.forEach(b=>{const c=document.createElement("div");c.className="chip ex";c.textContent="+ "+b;
+  c.onclick=()=>addBench(b); bs.appendChild(c);});
+// region
+$$("#region button").forEach(b=>b.onclick=()=>{$$("#region button").forEach(x=>x.classList.remove("on"));b.classList.add("on");state.region=b.dataset.v;});
+
+// step navigation
+let cur=0;
+function go(n){cur=n; $$(".step").forEach((s,i)=>s.classList.toggle("active",i===n));
+  $$(".progress .dot").forEach((d,i)=>d.classList.toggle("on",i<=n));
+  if(n===2) buildResult(); window.scrollTo({top:0,behavior:"smooth"});}
+$("#next0").onclick=()=>go(1);
+$("#back1").onclick=()=>go(0);
+$("#next1").onclick=()=>go(2);
+$("#back2").onclick=()=>go(1);
+$("#restart").onclick=()=>{state.area="";state.lenses.clear();state.benchmarks=[];state.region="국내 중심";
+  $("#area").value="";$("#next0").disabled=true;$$("#lenses .chip").forEach(c=>c.classList.remove("sel"));
+  $("#benchTags").innerHTML="";$$("#region button").forEach((x,i)=>x.classList.toggle("on",i===0));go(0);};
+
+function slug(s){return (s||"").toLowerCase().replace(/[^a-z0-9가-힣]+/g,"-").replace(/^-|-$/g,"")||"new-area";}
+function buildResult(){
+  const cfg={
+    area:state.area,
+    company_context:"생명보험사 신사업추진",
+    strategic_lenses:[...state.lenses],
+    benchmarks:state.benchmarks,
+    region:state.region,
+    output:"interactive_report",
+    report_path:"reports/"+slug(state.area)+".html"
+  };
+  // summary
+  const sm=$("#summary");
+  sm.innerHTML=`
+    <div class="k"><div class="l">신사업 영역</div><div class="v">${state.area||"-"}</div></div>
+    <div class="k"><div class="l">지역 범위</div><div class="v">${state.region}</div></div>
+    <div class="k"><div class="l">전략 관점</div><div class="v">${[...state.lenses].join(", ")||"(미지정)"}</div></div>
+    <div class="k"><div class="l">벤치마크</div><div class="v">${state.benchmarks.join(", ")||"(미지정)"}</div></div>`;
+  // prompt
+  const prompt=
+`신사업 발굴 에이전트 실행 — 아래 설정으로 진행해줘.
+시장조사·경쟁환경·규제 3개 도메인 서브에이전트를 병렬로 리서치한 뒤,
+진입 초기의견(시장매력도·경쟁강도·규제난이도·생보사 적합성 → Go/Watch/No-go)으로 종합하고,
+report_path에 인터랙티브 리포트(reports 템플릿의 REPORT 객체 형식)를 생성·커밋해줘.
+
+`+JSON.stringify(cfg,null,2);
+  $("#prompt").textContent=prompt;
+  // demo
+  const r=findReport(state.area);
+  const box=$("#demoBox");
+  if(r){box.style.display="flex"; $("#demoLink").href=r.url;}
+  else box.style.display="none";
+}
+$("#copyPrompt").onclick=()=>{navigator.clipboard.writeText($("#prompt").textContent).then(()=>{
+  const b=$("#copyPrompt");b.textContent="복사됨 ✓";setTimeout(()=>b.textContent="복사",1500);});};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 개요
신사업 발굴 에이전트의 **진입 위저드 웹페이지**(`index.html`)를 추가합니다. 채팅이 아니라 웹 UX로 영역을 지정하고 세부 선택 후 인터랙티브 리포트로 이어지는 흐름입니다.

## UX 흐름 (정적 위저드)
1. **STEP 1 — 영역 입력** (예시 칩 포함)
2. **STEP 2 — 세부 선택**: 전략 관점(렌즈) · 벤치마크 기업(태그) · 지역 범위
3. **STEP 3 — 실행 준비**: 리서치 설정(JSON) + 발굴 에이전트 실행 프롬프트(복사 버튼) 생성, 이미 생성된 리포트는 데모 결과로 연결

## 동작 방식
- 정적 사이트라 리서치 엔진(LLM+웹검색)은 페이지가 직접 수행하지 않고, 위저드가 만든 **설정/프롬프트를 Claude Code 발굴 에이전트가 받아 실행**하는 반자동 구조입니다. (완전 자동 백엔드는 Phase 2 이후)
- 외부 의존성 없는 vanilla JS/CSS, 반응형. jsdom 플로우 검증 완료(런타임 에러 0).

## ⚠️ 머지 영향
`index.html`이 루트에 추가되어 **사이트 홈(https://seokkimoon.github.io/)** 이 이 위저드로 바뀝니다(기존 README 홈 대체).

https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC)_