### PR TITLE
로컬 브리지(B): 구독(Claude Code) 실행 — 종량 API 불필요

### DIFF
--- a/tools/local-agent/README.md
+++ b/tools/local-agent/README.md
@@ -1,0 +1,41 @@
+# 신사업 발굴 — 로컬 브리지 (구독 실행, 종량 API 불필요)
+
+브라우저 폼에서 영역을 입력하면, **본 PC의 Claude Code(`claude -p`)** 가 구독 인증으로
+시장·경쟁·규제를 **내장 웹검색**으로 리서치하고 인터랙티브 리포트로 렌더합니다.
+**Anthropic 종량 API 키가 필요 없습니다.**
+
+## 동작 방식
+```
+브라우저 폼  →  로컬 서버(server.mjs)  →  claude -p (구독 인증 + 내장 WebSearch)
+                                            → REPORT JSON  →  reports/report.html 렌더
+```
+
+## 사전 조건
+1. **Node.js 18+**
+2. **Claude Code CLI** 설치 후 **구독 로그인**
+   ```bash
+   npm install -g @anthropic-ai/claude-code   # 설치(이미 있으면 생략)
+   claude                                      # 실행 → /login 으로 구독(Pro/Max) 로그인
+   ```
+   > 로그인이 종량 API 키가 아니라 **구독 계정**으로 되어 있어야 구독 한도로 청구됩니다.
+
+## 실행
+레포 루트에서:
+```bash
+node tools/local-agent/server.mjs
+```
+그러면 콘솔에 주소가 뜹니다 → 브라우저로 **http://localhost:4178** 접속 →
+영역·옵션 선택 → **리서치 생성**.
+
+- 포트 변경: `PORT=5000 node tools/local-agent/server.mjs`
+- claude 실행파일 경로 지정: `CLAUDE_BIN=/path/to/claude node tools/local-agent/server.mjs`
+
+## 요금
+- 리서치는 `claude -p`(헤드리스)로 실행되며 **월별 Agent SDK 크레딧**(구독에 포함, Pro 약 $20 / Max 약 $100~200 상당)에서 차감됩니다. **별도 충전 불필요**, 매월 리셋.
+- 이 월 크레딧을 **초과하면** 종량제 API로 넘어갑니다(그때는 API 결제 필요).
+- 정확한 정책·금액은 https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan 에서 확인.
+
+## 참고
+- 결과 품질은 프롬프트/스키마(`server.mjs`의 `SCHEMA`·`SYS`)를 조정해 튜닝할 수 있습니다.
+- 리포트 렌더러는 공개 사이트와 동일한 `reports/report.html`(데이터 구동형)을 재사용합니다.
+- 이 도구는 **로컬 전용**입니다. 사내 공유가 필요하면 사내망 서버에 올리고 접근제어를 두세요(공개 인터넷 노출 금지).

--- a/tools/local-agent/public/index.html
+++ b/tools/local-agent/public/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>신사업 발굴 (로컬 · 구독)</title>
+<style>
+  :root{--navy:#0f3a5f;--navy2:#16527f;--teal:#14b8a6;--slate:#475569;--line:#e2e8f0;--bg:#f6f8fb;--muted:#64748b}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:#0f172a;line-height:1.6;
+    font-family:-apple-system,BlinkMacSystemFont,"Apple SD Gothic Neo","Malgun Gothic",sans-serif}
+  .wrap{max-width:720px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(135deg,var(--navy),var(--navy2));color:#fff;padding:34px 0 26px}
+  header .tag{display:inline-block;font-size:12px;background:rgba(255,255,255,.15);padding:4px 11px;border-radius:999px;margin-bottom:10px}
+  header h1{margin:0 0 6px;font-size:25px;font-weight:800}
+  header p{margin:0;color:#cfe2f1;font-size:13.5px}
+  main{padding:26px 0 60px}
+  .card{background:#fff;border:1px solid var(--line);border-radius:16px;box-shadow:0 8px 24px rgba(15,23,42,.06);padding:24px}
+  label.fl{display:block;font-size:13px;font-weight:700;color:var(--slate);margin:18px 0 8px}
+  label.fl:first-child{margin-top:0}
+  input[type=text]{width:100%;padding:12px 14px;font-size:15px;border:1.5px solid var(--line);border-radius:11px;outline:none;font-family:inherit}
+  input[type=text]:focus{border-color:var(--teal);box-shadow:0 0 0 3px rgba(20,184,166,.12)}
+  .chips{display:flex;flex-wrap:wrap;gap:8px}
+  .chip{font-size:13px;font-weight:600;padding:8px 13px;border-radius:999px;border:1.5px solid var(--line);background:#fff;color:var(--slate);cursor:pointer;user-select:none}
+  .chip.sel{background:var(--navy);border-color:var(--navy);color:#fff}
+  .chip.ex{border-style:dashed;color:var(--navy2)}
+  .seg{display:inline-flex;border:1.5px solid var(--line);border-radius:11px;overflow:hidden}
+  .seg button{border:none;background:#fff;padding:10px 18px;font-size:14px;font-weight:600;color:var(--slate);cursor:pointer}
+  .seg button.on{background:var(--navy);color:#fff}
+  .tags{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+  .tag{display:inline-flex;align-items:center;gap:7px;background:#eef6f5;color:#0f766e;border:1px solid #99f6e4;font-size:13px;font-weight:600;padding:6px 10px;border-radius:9px}
+  .tag b{cursor:pointer;opacity:.6}
+  .tagrow{display:flex;gap:8px;margin-top:8px}
+  .tagrow input{flex:1}
+  .addbtn{border:1.5px solid var(--navy);background:var(--navy);color:#fff;border-radius:11px;padding:0 16px;font-weight:700;cursor:pointer}
+  .go{margin-top:22px;width:100%;border:none;background:var(--teal);color:#fff;border-radius:12px;padding:14px;font-size:16px;font-weight:800;cursor:pointer}
+  .go:disabled{opacity:.5;cursor:not-allowed}
+  .hint{font-size:12.5px;color:var(--muted);margin-top:10px}
+  #log{display:none;margin-top:16px;background:#0f1f2e;color:#9fb6cb;border-radius:12px;padding:14px;font-size:12.5px;line-height:1.7;max-height:240px;overflow:auto;font-family:ui-monospace,Menlo,Consolas,monospace}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <span class="tag">로컬 브리지 · 구독(Claude Code) 실행</span>
+  <h1>신사업 발굴 에이전트</h1>
+  <p>본 PC의 Claude Code(구독 인증·웹검색 내장)로 리서치합니다. 종량 API 키 불필요.</p>
+</div></header>
+<main><div class="wrap"><div class="card">
+  <label class="fl">신사업 영역</label>
+  <input type="text" id="area" placeholder="예) AI 웰니스로봇" autocomplete="off" />
+  <div class="chips" id="examples" style="margin-top:8px"></div>
+
+  <label class="fl">전략 관점 (렌즈) · 복수 선택</label>
+  <div class="chips" id="lenses"></div>
+
+  <label class="fl">벤치마크 기업</label>
+  <div class="tagrow"><input type="text" id="benchInput" placeholder="기업명 입력 후 Enter" autocomplete="off" /><button class="addbtn" id="benchAdd">추가</button></div>
+  <div class="tags" id="benchTags"></div>
+
+  <label class="fl">지역 범위</label>
+  <div class="seg" id="region"><button data-v="국내 중심" class="on">국내 중심</button><button data-v="글로벌 포함">글로벌 포함</button></div>
+
+  <button class="go" id="genBtn">리서치 생성 →</button>
+  <div class="hint">완료까지 수분 소요(웹검색 다회). 구독 한도 내에서 추가 종량과금 없이 실행됩니다.</div>
+  <div id="log"></div>
+</div></div></main>
+<script>
+const $=s=>document.querySelector(s),$$=s=>[...document.querySelectorAll(s)];
+const state={area:"",lenses:new Set(),benchmarks:[],region:"국내 중심"};
+const EX=["AI 웰니스로봇","시니어 요양·시니어케어","마이데이터·금융플랫폼","디지털 헬스케어","펫 보험·헬스케어"];
+const LENSES=["건강증진형 보험 연계","시니어·요양 사업","헬스케어 데이터 활용","신채널·플랫폼","투자·M&A(지분)","ESG·공적연계"];
+EX.forEach(e=>{const c=document.createElement("div");c.className="chip ex";c.textContent=e;c.onclick=()=>{$("#area").value=e;state.area=e;};$("#examples").appendChild(c);});
+$("#area").addEventListener("input",e=>state.area=e.target.value.trim());
+LENSES.forEach(l=>{const c=document.createElement("div");c.className="chip";c.textContent=l;c.onclick=()=>{if(state.lenses.has(l)){state.lenses.delete(l);c.classList.remove("sel");}else{state.lenses.add(l);c.classList.add("sel");}};$("#lenses").appendChild(c);});
+function renderTags(){const t=$("#benchTags");t.innerHTML="";state.benchmarks.forEach((b,i)=>{const s=document.createElement("span");s.className="tag";s.innerHTML=b+" <b>✕</b>";s.querySelector("b").onclick=()=>{state.benchmarks.splice(i,1);renderTags();};t.appendChild(s);});}
+function addBench(v){v=(v||"").trim();if(v&&!state.benchmarks.includes(v)){state.benchmarks.push(v);renderTags();}}
+$("#benchAdd").onclick=()=>{addBench($("#benchInput").value);$("#benchInput").value="";};
+$("#benchInput").addEventListener("keydown",e=>{if(e.key==="Enter"){e.preventDefault();addBench(e.target.value);e.target.value="";}});
+$$("#region button").forEach(b=>b.onclick=()=>{$$("#region button").forEach(x=>x.classList.remove("on"));b.classList.add("on");state.region=b.dataset.v;});
+function log(t){const b=$("#log");b.style.display="block";const d=document.createElement("div");d.textContent=t;b.appendChild(d);b.scrollTop=b.scrollHeight;}
+$("#genBtn").onclick=async()=>{
+  if(!state.area){alert("신사업 영역을 입력하세요.");return;}
+  const btn=$("#genBtn");btn.disabled=true;const orig=btn.textContent;btn.textContent="생성 중… (수분 소요)";$("#log").innerHTML="";
+  log("Claude Code(구독)로 리서치 시작 — 영역: "+state.area);
+  log("※ 웹검색을 여러 번 수행하므로 완료까지 시간이 걸립니다.");
+  try{
+    const res=await fetch("/generate",{method:"POST",headers:{"content-type":"application/json"},
+      body:JSON.stringify({area:state.area,lenses:[...state.lenses],benchmarks:state.benchmarks,region:state.region})});
+    const data=await res.json();
+    if(!data.ok)throw new Error(data.error||"생성 실패");
+    sessionStorage.setItem("nbd_report",JSON.stringify(data.report));
+    log("✅ 완료 — 리포트로 이동합니다");
+    location.href="/report.html";
+  }catch(e){log("✗ 오류: "+(e&&e.message||e));log("※ 터미널 로그와 claude 로그인 상태를 확인하세요.");btn.disabled=false;btn.textContent=orig;}
+};
+</script>
+</body>
+</html>

--- a/tools/local-agent/server.mjs
+++ b/tools/local-agent/server.mjs
@@ -1,0 +1,98 @@
+// 신사업 발굴 — 로컬 브리지 서버 (의존성 0, Node 18+)
+// 브라우저 폼 → claude -p (Claude Code 헤드리스, 구독 인증, 웹검색 내장) → REPORT JSON → 리포트 렌더
+// 종량 API 키 불필요. 사전조건: `claude` CLI 설치 + 구독 로그인(`claude` 실행 후 /login).
+
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = process.env.PORT || 4178;
+const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
+const REPORT_HTML = join(__dirname, '..', '..', 'reports', 'report.html');
+const INDEX_HTML = join(__dirname, 'public', 'index.html');
+
+const SCHEMA = '{meta:{tag,title,subtitle,foot}, verdict:{badge:"조건부 Go|관망(Watch)|진입 보류(No-go) 중 한국어",text}, kpis:[{label,value,sub}](정확히 4개), scores:{labels:["시장 매력도","경쟁 우호도","규제 용이성","전략적 적합성"],values:[0~5 숫자 4개]}, summaryPoints:[문장 3~5], market:{sizes:{categories:[카테고리 2~3],y2024:[숫자],y2030:[숫자],unit:"예: 억 USD"},cagr:{labels:[3~4],values:[숫자 %]},funnel:[{t,v}](TAM,SAM,SOM 3개),drivers:[문장 4]}, competition:{players:[{n:이름,x:0~10 상용화성숙도,y:0~10 프리미엄,r:8~24 영향력,c:"#hex"}](4~8),forces:[{n,lvl:"높음|중간|낮음",v:0~100}](5개: 신규진입/공급자/구매자/대체재/기존경쟁),incumbents:[문장],players_table:[[기업,포지션,모델,상태,"hi|mid|lo"]]}, regulation:{flow:[{h,d}](4단계),checklist:[[경로,규제관문,핵심점검]](Build,Borrow,Buy)}, opinion:{reco:문장,bbbChart:{criteria:["실행 속도","자본 효율","역량 내재화","리스크 관리"],Build:[0~5 4개],Borrow:[4개],Buy:[4개]},bbb:[{name:"Build",tag,cls:"vt-no",note},{name:"Borrow",tag,cls:"vt-rec",note},{name:"Buy",tag,cls:"vt-opt",note}],nextSteps:[문장]}, sources:{"시장조사":[[제목,url]],"경쟁환경":[[제목,url]],"규제":[[제목,url]]}}';
+
+const SYS = "당신은 한국 생명보험사 신사업추진파트의 '발굴 에이전트'입니다. WebSearch/WebFetch 도구로 시장규모·성장률·동인, 경쟁 플레이어·다이내믹스, 규제(특히 생명보험사 진입요건: 보험업법 부수/겸영업무·자회사 출자 §115·건강증진형 보험 가이드라인)를 조사한 뒤, 생보사 진입 관점의 진입 초기의견(시장매력도·경쟁강도·규제난이도·전략적 적합성 → Go/Watch/No-go)으로 종합합니다. 한국 1차 출처를 우선하고 수치엔 출처·연도를 반영하세요. 규제는 1차 의견이며 최종 법무·컴플라이언스 검토가 필요합니다.";
+
+function buildPrompt(cfg) {
+  const lenses = (cfg.lenses || []).join(', ') || '제한 없음';
+  const bench = (cfg.benchmarks || []).join(', ') || '없음';
+  return `${SYS}
+
+아래 신사업 영역을 WebSearch로 조사해 진입 리포트를 만들어줘. 모든 텍스트는 한국어.
+영역: ${cfg.area}
+전략 관점(렌즈): ${lenses}
+벤치마크 기업: ${bench}
+지역 범위: ${cfg.region || '국내 중심'}
+
+조사를 마치면, 아래 스키마에 정확히 맞는 JSON 객체 "하나만" 출력해줘. 코드펜스/설명/서론 없이 순수 JSON만, 마지막 출력이 그 JSON이어야 함.
+스키마: ${SCHEMA}`;
+}
+
+function runClaude(prompt) {
+  return new Promise((resolve, reject) => {
+    const args = ['-p', prompt, '--output-format', 'json', '--allowedTools', 'WebSearch,WebFetch'];
+    const cp = spawn(CLAUDE_BIN, args, { cwd: __dirname });
+    let out = '', err = '';
+    cp.stdout.on('data', d => (out += d));
+    cp.stderr.on('data', d => (err += d));
+    cp.on('error', e => reject(new Error('claude 실행 실패(설치/PATH 확인): ' + e.message)));
+    cp.on('close', code => {
+      if (!out) return reject(new Error('claude 종료코드 ' + code + ': ' + (err.slice(0, 400) || '출력 없음')));
+      resolve(out);
+    });
+  });
+}
+
+function extractReport(raw) {
+  let text = raw;
+  try { const env = JSON.parse(raw); if (env && typeof env.result === 'string') text = env.result; } catch (e) {}
+  const m = text.match(/\{[\s\S]*\}/);
+  if (!m) throw new Error('출력에서 REPORT JSON을 찾지 못했습니다');
+  return JSON.parse(m[0]);
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && (req.url === '/' || req.url.startsWith('/?'))) {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    return res.end(readFileSync(INDEX_HTML));
+  }
+  if (req.method === 'GET' && req.url.startsWith('/report.html')) {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    return res.end(readFileSync(REPORT_HTML));
+  }
+  if (req.method === 'POST' && req.url === '/generate') {
+    let body = '';
+    req.on('data', c => (body += c));
+    req.on('end', async () => {
+      try {
+        const cfg = JSON.parse(body || '{}');
+        if (!cfg.area) throw new Error('영역(area)이 비었습니다');
+        console.log('[generate] 영역:', cfg.area, '— claude -p 실행 중…');
+        const raw = await runClaude(buildPrompt(cfg));
+        const report = extractReport(raw);
+        console.log('[generate] 완료');
+        res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ ok: true, report }));
+      } catch (e) {
+        console.error('[generate] 오류:', e.message);
+        res.writeHead(500, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ ok: false, error: String(e.message || e) }));
+      }
+    });
+    return;
+  }
+  res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+  res.end('not found');
+});
+
+server.listen(PORT, () => {
+  console.log('\n  신사업 발굴 — 로컬 브리지');
+  console.log('  → http://localhost:' + PORT);
+  console.log('  (Claude Code 구독 인증 + 내장 WebSearch 사용 · 종량 API 키 불필요)');
+  console.log('  사전조건: claude CLI 설치 + 구독 로그인(claude 실행 후 /login)\n');
+});


### PR DESCRIPTION
## 개요
**B 방식 — 로컬 브리지.** 브라우저 폼 → 본 PC의 **Claude Code(`claude -p`, 구독 인증·내장 웹검색)** 로 리서치 → REPORT JSON → 리포트 렌더. **종량 API 키 불필요**(구독 한도 내 실행).

## 추가 파일 (`tools/local-agent/`)
- **`server.mjs`** — 의존성 0 Node 서버. `/generate`가 `claude -p <prompt> --output-format json --allowedTools WebSearch,WebFetch` 실행 → 출력에서 REPORT JSON 추출. `/report.html`은 공개본과 동일 렌더러 재사용.
- **`public/index.html`** — 경량 위저드(영역·렌즈·벤치마크·지역) + 진행 로그.
- **`README.md`** — 사전조건(claude CLI 구독 로그인)·실행·요금 안내.

## 동작
```
브라우저 폼 → server.mjs → claude -p (구독+WebSearch) → REPORT JSON → reports/report.html
```

## 요금
`claude -p`는 **월별 Agent SDK 크레딧**(구독 포함, Pro ~$20 / Max ~$100~200 상당)에서 차감 — 별도 충전 불필요, 매월 리셋. 초과 시에만 종량 API로 전환.

## 검증
`node --check` 통과, 페이지 스크립트 구문 OK, `extractReport`(엔벨로프/순수 JSON) 단위 확인. 실제 `claude -p` 라운드트립은 사용자 PC(claude CLI 구독 로그인)에서 확인 필요 — 이 샌드박스엔 CLI 미존재.

## 참고
로컬 전용 도구입니다(공개 사이트 미노출). 사내 공유 시 접근제어 있는 사내망에 배치 권장.

https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC)_