### PR TITLE
브리지 공유 암호 + 일일 사용제한 (외부 공개 대비)

### DIFF
--- a/tools/local-agent/public/index.html
+++ b/tools/local-agent/public/index.html
@@ -60,6 +60,9 @@
   <label class="fl">지역 범위</label>
   <div class="seg" id="region"><button data-v="국내 중심" class="on">국내 중심</button><button data-v="글로벌 포함">글로벌 포함</button></div>
 
+  <label class="fl">접속 암호</label>
+  <input type="password" id="pass" placeholder="관리자에게 받은 접속 암호" autocomplete="off" />
+
   <button class="go" id="genBtn">리서치 생성 →</button>
   <div class="hint">완료까지 수분 소요(웹검색 다회). 구독 한도 내에서 추가 종량과금 없이 실행됩니다.</div>
   <div id="log"></div>
@@ -78,14 +81,16 @@ $("#benchAdd").onclick=()=>{addBench($("#benchInput").value);$("#benchInput").va
 $("#benchInput").addEventListener("keydown",e=>{if(e.key==="Enter"){e.preventDefault();addBench(e.target.value);e.target.value="";}});
 $$("#region button").forEach(b=>b.onclick=()=>{$$("#region button").forEach(x=>x.classList.remove("on"));b.classList.add("on");state.region=b.dataset.v;});
 function log(t){const b=$("#log");b.style.display="block";const d=document.createElement("div");d.textContent=t;b.appendChild(d);b.scrollTop=b.scrollHeight;}
+try{const p=localStorage.getItem("nbd_pass");if(p)$("#pass").value=p;}catch(e){}
 $("#genBtn").onclick=async()=>{
   if(!state.area){alert("신사업 영역을 입력하세요.");return;}
+  try{localStorage.setItem("nbd_pass",$("#pass").value);}catch(e){}
   const btn=$("#genBtn");btn.disabled=true;const orig=btn.textContent;btn.textContent="생성 중… (수분 소요)";$("#log").innerHTML="";
   log("Claude Code(구독)로 리서치 시작 — 영역: "+state.area);
   log("※ 웹검색을 여러 번 수행하므로 완료까지 시간이 걸립니다.");
   try{
     const res=await fetch("/generate",{method:"POST",headers:{"content-type":"application/json"},
-      body:JSON.stringify({area:state.area,lenses:[...state.lenses],benchmarks:state.benchmarks,region:state.region})});
+      body:JSON.stringify({area:state.area,lenses:[...state.lenses],benchmarks:state.benchmarks,region:state.region,password:$("#pass").value})});
     const data=await res.json();
     if(!data.ok)throw new Error(data.error||"생성 실패");
     sessionStorage.setItem("nbd_report",JSON.stringify(data.report));

--- a/tools/local-agent/server.mjs
+++ b/tools/local-agent/server.mjs
@@ -13,6 +13,9 @@ const PORT = process.env.PORT || 4178;
 const CLAUDE_BIN = process.env.CLAUDE_BIN || 'claude';
 const REPORT_HTML = join(__dirname, '..', '..', 'reports', 'report.html');
 const INDEX_HTML = join(__dirname, 'public', 'index.html');
+const BRIDGE_PASSWORD = process.env.BRIDGE_PASSWORD || '';
+const DAILY_LIMIT = parseInt(process.env.BRIDGE_DAILY_LIMIT || '30', 10);
+const usage = { date: '', count: 0 };
 
 const SCHEMA = '{meta:{tag,title,subtitle,foot}, verdict:{badge:"조건부 Go|관망(Watch)|진입 보류(No-go) 중 한국어",text}, kpis:[{label,value,sub}](정확히 4개), scores:{labels:["시장 매력도","경쟁 우호도","규제 용이성","전략적 적합성"],values:[0~5 숫자 4개]}, summaryPoints:[문장 3~5], market:{sizes:{categories:[카테고리 2~3],y2024:[숫자],y2030:[숫자],unit:"예: 억 USD"},cagr:{labels:[3~4],values:[숫자 %]},funnel:[{t,v}](TAM,SAM,SOM 3개),drivers:[문장 4]}, competition:{players:[{n:이름,x:0~10 상용화성숙도,y:0~10 프리미엄,r:8~24 영향력,c:"#hex"}](4~8),forces:[{n,lvl:"높음|중간|낮음",v:0~100}](5개: 신규진입/공급자/구매자/대체재/기존경쟁),incumbents:[문장],players_table:[[기업,포지션,모델,상태,"hi|mid|lo"]]}, regulation:{flow:[{h,d}](4단계),checklist:[[경로,규제관문,핵심점검]](Build,Borrow,Buy)}, opinion:{reco:문장,bbbChart:{criteria:["실행 속도","자본 효율","역량 내재화","리스크 관리"],Build:[0~5 4개],Borrow:[4개],Buy:[4개]},bbb:[{name:"Build",tag,cls:"vt-no",note},{name:"Borrow",tag,cls:"vt-rec",note},{name:"Buy",tag,cls:"vt-opt",note}],nextSteps:[문장]}, sources:{"시장조사":[[제목,url]],"경쟁환경":[[제목,url]],"규제":[[제목,url]]}}';
 
@@ -71,8 +74,19 @@ const server = http.createServer((req, res) => {
     req.on('end', async () => {
       try {
         const cfg = JSON.parse(body || '{}');
+        if (BRIDGE_PASSWORD && cfg.password !== BRIDGE_PASSWORD) {
+          res.writeHead(401, { 'content-type': 'application/json; charset=utf-8' });
+          return res.end(JSON.stringify({ ok: false, error: '접속 암호가 올바르지 않습니다.' }));
+        }
+        const today = new Date().toISOString().slice(0, 10);
+        if (usage.date !== today) { usage.date = today; usage.count = 0; }
+        if (DAILY_LIMIT > 0 && usage.count >= DAILY_LIMIT) {
+          res.writeHead(429, { 'content-type': 'application/json; charset=utf-8' });
+          return res.end(JSON.stringify({ ok: false, error: '오늘 사용 한도(' + DAILY_LIMIT + '건)를 초과했습니다. 내일 다시 시도하세요.' }));
+        }
         if (!cfg.area) throw new Error('영역(area)이 비었습니다');
-        console.log('[generate] 영역:', cfg.area, '— claude -p 실행 중…');
+        usage.count++;
+        console.log('[generate] 영역:', cfg.area, '— claude -p 실행 중… (' + usage.count + '/' + DAILY_LIMIT + ')');
         const raw = await runClaude(buildPrompt(cfg));
         const report = extractReport(raw);
         console.log('[generate] 완료');
@@ -94,5 +108,7 @@ server.listen(PORT, () => {
   console.log('\n  신사업 발굴 — 로컬 브리지');
   console.log('  → http://localhost:' + PORT);
   console.log('  (Claude Code 구독 인증 + 내장 WebSearch 사용 · 종량 API 키 불필요)');
+  console.log('  접속 암호: ' + (BRIDGE_PASSWORD ? '설정됨 ✅' : '없음 ⚠️ (외부 공개 시 BRIDGE_PASSWORD 환경변수로 꼭 설정)'));
+  console.log('  일일 사용 한도: ' + (DAILY_LIMIT > 0 ? DAILY_LIMIT + '건' : '제한 없음'));
   console.log('  사전조건: claude CLI 설치 + 구독 로그인(claude 실행 후 /login)\n');
 });


### PR DESCRIPTION
## 개요
로컬 브리지를 외부 공개(Quick Tunnel) 대비로 보강 — **공유 암호 + 일일 사용제한** 추가.

## 변경
- `server.mjs`: `BRIDGE_PASSWORD` 설정 시 `/generate`에 암호 필수(미입력/오답 → 401). `BRIDGE_DAILY_LIMIT`(기본 30) 초과 → 429. 시작 로그에 암호/한도 상태 표시.
- `public/index.html`: 접속 암호 입력란(localStorage 저장) + 요청에 동봉.

## 검증
모의 claude로 401(무·오답)/200(정답)/429(한도초과) 모두 확인.

https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC)_