### PR TITLE
리서처 강화: 오케스트레이터(3 병렬 리서처 + 종합)

### DIFF
--- a/tools/local-agent/README.md
+++ b/tools/local-agent/README.md
@@ -4,11 +4,15 @@
 시장·경쟁·규제를 **내장 웹검색**으로 리서치하고 인터랙티브 리포트로 렌더합니다.
 **Anthropic 종량 API 키가 필요 없습니다.**
 
-## 동작 방식
+## 동작 방식 (오케스트레이터: 3 리서처 병렬 + 종합)
 ```
-브라우저 폼  →  로컬 서버(server.mjs)  →  claude -p (구독 인증 + 내장 WebSearch)
-                                            → REPORT JSON  →  reports/report.html 렌더
+브라우저 폼 → server.mjs → ┌ claude -p (시장 리서처) ┐
+   (POST /generate,        ├ claude -p (경쟁 리서처) ┤ 병렬 → claude -p (종합) → REPORT JSON
+    jobId 즉시 반환)        └ claude -p (규제 리서처) ┘                         → reports/report.html
+   GET /status?id=.. 폴링으로 진행상황(시장/경쟁/규제/종합) 표시
 ```
+- 1건당 **`claude -p` 4회**(병렬 3 + 종합)로, 단일 패스보다 깊지만 시간·구독 크레딧이 약 3~4배입니다.
+- 비동기 작업+폴링 구조라 장시간 실행도 (터널의) 요청 타임아웃에 걸리지 않습니다.
 
 ## 사전 조건
 1. **Node.js 18+**

--- a/tools/local-agent/public/index.html
+++ b/tools/local-agent/public/index.html
@@ -82,21 +82,29 @@ $("#benchInput").addEventListener("keydown",e=>{if(e.key==="Enter"){e.preventDef
 $$("#region button").forEach(b=>b.onclick=()=>{$$("#region button").forEach(x=>x.classList.remove("on"));b.classList.add("on");state.region=b.dataset.v;});
 function log(t){const b=$("#log");b.style.display="block";const d=document.createElement("div");d.textContent=t;b.appendChild(d);b.scrollTop=b.scrollHeight;}
 try{const p=localStorage.getItem("nbd_pass");if(p)$("#pass").value=p;}catch(e){}
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
 $("#genBtn").onclick=async()=>{
   if(!state.area){alert("신사업 영역을 입력하세요.");return;}
   try{localStorage.setItem("nbd_pass",$("#pass").value);}catch(e){}
   const btn=$("#genBtn");btn.disabled=true;const orig=btn.textContent;btn.textContent="생성 중… (수분 소요)";$("#log").innerHTML="";
-  log("Claude Code(구독)로 리서치 시작 — 영역: "+state.area);
-  log("※ 웹검색을 여러 번 수행하므로 완료까지 시간이 걸립니다.");
+  log("리서치 시작 — 시장·경쟁·규제 3개 리서처 병렬 + 종합 ("+state.area+")");
+  log("※ 4회의 심층 리서치라 수분 소요됩니다. 창을 닫지 마세요.");
   try{
     const res=await fetch("/generate",{method:"POST",headers:{"content-type":"application/json"},
       body:JSON.stringify({area:state.area,lenses:[...state.lenses],benchmarks:state.benchmarks,region:state.region,password:$("#pass").value})});
     const data=await res.json();
-    if(!data.ok)throw new Error(data.error||"생성 실패");
-    sessionStorage.setItem("nbd_report",JSON.stringify(data.report));
-    log("✅ 완료 — 리포트로 이동합니다");
-    location.href="/report.html";
-  }catch(e){log("✗ 오류: "+(e&&e.message||e));log("※ 터미널 로그와 claude 로그인 상태를 확인하세요.");btn.disabled=false;btn.textContent=orig;}
+    if(!data.ok)throw new Error(data.error||"시작 실패");
+    const jobId=data.jobId;
+    let last="";
+    while(true){
+      await sleep(3000);
+      let s;
+      try{ s=await (await fetch("/status?id="+encodeURIComponent(jobId))).json(); }catch(e){ continue; }
+      if(s.steps){const t="진행 — 시장:"+s.steps.market+" / 경쟁:"+s.steps.competition+" / 규제:"+s.steps.regulation+" / 종합:"+s.steps.synth;if(t!==last){log(t);last=t;}}
+      if(s.state==="done"){sessionStorage.setItem("nbd_report",JSON.stringify(s.report));log("✅ 완료 — 리포트로 이동합니다");location.href="/report.html";return;}
+      if(s.state==="error")throw new Error(s.error||"생성 실패");
+    }
+  }catch(e){log("✗ 오류: "+(e&&e.message||e));log("※ 브리지 터미널 로그와 claude 로그인 상태를 확인하세요.");btn.disabled=false;btn.textContent=orig;}
 };
 </script>
 </body>

--- a/tools/local-agent/server.mjs
+++ b/tools/local-agent/server.mjs
@@ -1,12 +1,14 @@
 // 신사업 발굴 — 로컬 브리지 서버 (의존성 0, Node 18+)
-// 브라우저 폼 → claude -p (Claude Code 헤드리스, 구독 인증, 웹검색 내장) → REPORT JSON → 리포트 렌더
-// 종량 API 키 불필요. 사전조건: `claude` CLI 설치 + 구독 로그인(`claude` 실행 후 /login).
+// 오케스트레이터: 시장·경쟁·규제 3개 리서처 병렬(claude -p) → 종합 에이전트 → REPORT JSON → 리포트 렌더
+// 구독(Claude Code) 인증·내장 WebSearch 사용, 종량 API 키 불필요.
+// 비동기 작업: POST /generate → {jobId} 즉시 반환, GET /status?id=... 로 폴링.
 
 import http from 'node:http';
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.PORT || 4178;
@@ -16,27 +18,66 @@ const INDEX_HTML = join(__dirname, 'public', 'index.html');
 const BRIDGE_PASSWORD = process.env.BRIDGE_PASSWORD || '';
 const DAILY_LIMIT = parseInt(process.env.BRIDGE_DAILY_LIMIT || '30', 10);
 const usage = { date: '', count: 0 };
+const jobs = new Map(); // jobId -> { state, steps, report, error, ts }
 
 const SCHEMA = '{meta:{tag,title,subtitle,foot}, verdict:{badge:"조건부 Go|관망(Watch)|진입 보류(No-go) 중 한국어",text}, kpis:[{label,value,sub}](정확히 4개), scores:{labels:["시장 매력도","경쟁 우호도","규제 용이성","전략적 적합성"],values:[0~5 숫자 4개]}, summaryPoints:[문장 3~5], market:{sizes:{categories:[카테고리 2~3],y2024:[숫자],y2030:[숫자],unit:"예: 억 USD"},cagr:{labels:[3~4],values:[숫자 %]},funnel:[{t,v}](TAM,SAM,SOM 3개),drivers:[문장 4]}, competition:{players:[{n:이름,x:0~10 상용화성숙도,y:0~10 프리미엄,r:8~24 영향력,c:"#hex"}](4~8),forces:[{n,lvl:"높음|중간|낮음",v:0~100}](5개: 신규진입/공급자/구매자/대체재/기존경쟁),incumbents:[문장],players_table:[[기업,포지션,모델,상태,"hi|mid|lo"]]}, regulation:{flow:[{h,d}](4단계),checklist:[[경로,규제관문,핵심점검]](Build,Borrow,Buy)}, opinion:{reco:문장,bbbChart:{criteria:["실행 속도","자본 효율","역량 내재화","리스크 관리"],Build:[0~5 4개],Borrow:[4개],Buy:[4개]},bbb:[{name:"Build",tag,cls:"vt-no",note},{name:"Borrow",tag,cls:"vt-rec",note},{name:"Buy",tag,cls:"vt-opt",note}],nextSteps:[문장]}, sources:{"시장조사":[[제목,url]],"경쟁환경":[[제목,url]],"규제":[[제목,url]]}}';
 
-const SYS = "당신은 한국 생명보험사 신사업추진파트의 '발굴 에이전트'입니다. WebSearch/WebFetch 도구로 시장규모·성장률·동인, 경쟁 플레이어·다이내믹스, 규제(특히 생명보험사 진입요건: 보험업법 부수/겸영업무·자회사 출자 §115·건강증진형 보험 가이드라인)를 조사한 뒤, 생보사 진입 관점의 진입 초기의견(시장매력도·경쟁강도·규제난이도·전략적 적합성 → Go/Watch/No-go)으로 종합합니다. 한국 1차 출처를 우선하고 수치엔 출처·연도를 반영하세요. 규제는 1차 의견이며 최종 법무·컴플라이언스 검토가 필요합니다.";
+const ctx = (cfg) => `영역: ${cfg.area}\n전략 관점(렌즈): ${(cfg.lenses || []).join(', ') || '제한 없음'}\n벤치마크 기업: ${(cfg.benchmarks || []).join(', ') || '없음'}\n지역 범위: ${cfg.region || '국내 중심'}`;
 
-function buildPrompt(cfg) {
-  const lenses = (cfg.lenses || []).join(', ') || '제한 없음';
-  const bench = (cfg.benchmarks || []).join(', ') || '없음';
-  return `${SYS}
+const marketPrompt = (cfg) => `당신은 한국 생명보험사 신사업추진파트의 '시장조사 리서처'다. WebSearch/WebFetch로 깊이 조사하라. 한국 1차 출처 우선(통계청·보험연구원(KIRI)·산업연구원·증권사 리포트·글로벌 리서치사). 모든 수치에 출처·연도를 병기하고 최소 8개 이상 출처를 확보하라. 한국어.
 
-아래 신사업 영역을 WebSearch로 조사해 진입 리포트를 만들어줘. 모든 텍스트는 한국어.
-영역: ${cfg.area}
-전략 관점(렌즈): ${lenses}
-벤치마크 기업: ${bench}
-지역 범위: ${cfg.region || '국내 중심'}
+${ctx(cfg)}
 
-조사를 마치면, 아래 스키마에 정확히 맞는 JSON 객체 "하나만" 출력해줘. 코드펜스/설명/서론 없이 순수 JSON만, 마지막 출력이 그 JSON이어야 함.
-스키마: ${SCHEMA}`;
-}
+다음을 빠짐없이 조사해 정보 밀도 높은 한국어 마크다운 리포트로 작성하라:
+- 시장 정의와 규모(글로벌/국내, 연도·통화 명시)
+- 성장률(CAGR)·향후 5년 전망
+- 핵심 성장 동인
+- 세그먼트(용도별/고객층별)
+- 수요 트렌드
+- TAM/SAM/SOM 추정(가정 명시)
+끝에 '## 출처' 목록(제목 - URL)을 붙여라.`;
 
-function runClaude(prompt) {
+const compPrompt = (cfg) => `당신은 한국 생명보험사 신사업추진파트의 '경쟁환경 리서처'다. WebSearch/WebFetch로 깊이 조사하라. 출처는 DART 공시·IR·신뢰도 있는 언론·기업 공식. 수치엔 출처·연도, 최소 8개 출처. 한국어.
+
+${ctx(cfg)}
+
+다음을 빠짐없이 조사해 정보 밀도 높은 한국어 마크다운 리포트로 작성하라:
+- 주요 플레이어 맵(국내·해외): 비즈니스 모델·점유율·상태
+- 경쟁 다이내믹스(Porter 5 Forces)
+- 향후 시나리오
+- 경쟁사 진입 동향(타 보험사·통신·요양 등)
+- 생명보험사 관점 시사점(유력 제휴 후보 등)
+끝에 '## 출처' 목록(제목 - URL)을 붙여라.`;
+
+const regPrompt = (cfg) => `당신은 한국 생명보험사 신사업추진파트의 '규제 리서처'다. 핵심 과제: 업계 규제 + 생명보험사 진입요건. WebSearch/WebFetch로 조사. 1차 출처 우선(금융위·금감원·국가법령정보 law.go.kr·식약처·KIRI). 한국어.
+
+${ctx(cfg)}
+
+다음을 빠짐없이 조사해 한국어 마크다운 리포트로 작성하라:
+- 제품/업 자체 규제(해당 시 인허가·분류 등)
+- 데이터·개인정보 규제(해당 시)
+- 생명보험사 진입 규제: 보험업법 부수업무(제11조의2)/겸영업무(제11조), 자회사 출자·소유(제109·115조), 금융위·금감원 인허가, 건강증진형 보험상품 가이드라인 등
+- Build/Borrow/Buy 경로별 규제 관문 체크리스트
+'본 내용은 1차 의견이며 최종 법무·컴플라이언스 검토가 필요'함을 명시하라.
+끝에 '## 출처' 목록(제목 - URL)을 붙여라.`;
+
+const synthPrompt = (cfg, m, c, r) => `당신은 한국 생명보험사 신사업추진파트의 '진입의견 종합 에이전트'다. 아래 3개 도메인 리서치(시장/경쟁/규제)를 종합해 생보사 진입 관점의 진입 초기의견으로 정리하라. 시장매력도·경쟁강도·규제난이도·전략적 적합성을 평가하고 Go/Watch/No-go 권고와 Build/Borrow/Buy 방향을 도출하라.
+
+반드시 아래 스키마에 "정확히" 맞는 JSON 객체 하나만 출력하라(코드펜스/설명/서론 없이, 순수 JSON). 모든 텍스트 한국어. 수치·출처는 도메인 리서치에서 그대로 인용해 채워라(특히 sources는 각 도메인의 '출처' 목록에서 가져와라).
+스키마: ${SCHEMA}
+
+${ctx(cfg)}
+
+===== 시장 리서치 =====
+${m}
+
+===== 경쟁 리서치 =====
+${c}
+
+===== 규제 리서치 =====
+${r}`;
+
+function runClaudeText(prompt) {
   return new Promise((resolve, reject) => {
     const args = ['-p', prompt, '--output-format', 'json', '--allowedTools', 'WebSearch,WebFetch'];
     const cp = spawn(CLAUDE_BIN, args, { cwd: __dirname });
@@ -46,18 +87,42 @@ function runClaude(prompt) {
     cp.on('error', e => reject(new Error('claude 실행 실패(설치/PATH 확인): ' + e.message)));
     cp.on('close', code => {
       if (!out) return reject(new Error('claude 종료코드 ' + code + ': ' + (err.slice(0, 400) || '출력 없음')));
-      resolve(out);
+      let text = out;
+      try { const env = JSON.parse(out); if (env && typeof env.result === 'string') text = env.result; } catch (e) {}
+      resolve(text);
     });
   });
 }
 
-function extractReport(raw) {
-  let text = raw;
-  try { const env = JSON.parse(raw); if (env && typeof env.result === 'string') text = env.result; } catch (e) {}
+function extractJson(text) {
   const m = text.match(/\{[\s\S]*\}/);
-  if (!m) throw new Error('출력에서 REPORT JSON을 찾지 못했습니다');
+  if (!m) throw new Error('종합 결과에서 REPORT JSON을 찾지 못했습니다');
   return JSON.parse(m[0]);
 }
+
+async function orchestrate(jobId, cfg) {
+  const j = jobs.get(jobId);
+  try {
+    j.steps.market = j.steps.competition = j.steps.regulation = '조사 중';
+    const [m, c, r] = await Promise.all([
+      runClaudeText(marketPrompt(cfg)).then(x => { j.steps.market = '완료'; return x; }),
+      runClaudeText(compPrompt(cfg)).then(x => { j.steps.competition = '완료'; return x; }),
+      runClaudeText(regPrompt(cfg)).then(x => { j.steps.regulation = '완료'; return x; }),
+    ]);
+    j.steps.synth = '종합 중';
+    const text = await runClaudeText(synthPrompt(cfg, m, c, r));
+    j.report = extractJson(text);
+    j.steps.synth = '완료';
+    j.state = 'done';
+    console.log('[' + jobId.slice(0, 8) + '] 완료:', cfg.area);
+  } catch (e) {
+    j.state = 'error';
+    j.error = String(e.message || e);
+    console.error('[' + jobId.slice(0, 8) + '] 오류:', j.error);
+  }
+}
+
+const JSONH = { 'content-type': 'application/json; charset=utf-8' };
 
 const server = http.createServer((req, res) => {
   if (req.method === 'GET' && (req.url === '/' || req.url.startsWith('/?'))) {
@@ -68,33 +133,41 @@ const server = http.createServer((req, res) => {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
     return res.end(readFileSync(REPORT_HTML));
   }
+  if (req.method === 'GET' && req.url.startsWith('/status')) {
+    const id = new URL(req.url, 'http://x').searchParams.get('id');
+    const j = jobs.get(id);
+    res.writeHead(j ? 200 : 404, JSONH);
+    return res.end(JSON.stringify(j ? { state: j.state, steps: j.steps, error: j.error, report: j.state === 'done' ? j.report : null } : { error: 'no job' }));
+  }
   if (req.method === 'POST' && req.url === '/generate') {
     let body = '';
     req.on('data', c => (body += c));
-    req.on('end', async () => {
+    req.on('end', () => {
       try {
         const cfg = JSON.parse(body || '{}');
         if (BRIDGE_PASSWORD && cfg.password !== BRIDGE_PASSWORD) {
-          res.writeHead(401, { 'content-type': 'application/json; charset=utf-8' });
+          res.writeHead(401, JSONH);
           return res.end(JSON.stringify({ ok: false, error: '접속 암호가 올바르지 않습니다.' }));
         }
         const today = new Date().toISOString().slice(0, 10);
         if (usage.date !== today) { usage.date = today; usage.count = 0; }
         if (DAILY_LIMIT > 0 && usage.count >= DAILY_LIMIT) {
-          res.writeHead(429, { 'content-type': 'application/json; charset=utf-8' });
+          res.writeHead(429, JSONH);
           return res.end(JSON.stringify({ ok: false, error: '오늘 사용 한도(' + DAILY_LIMIT + '건)를 초과했습니다. 내일 다시 시도하세요.' }));
         }
-        if (!cfg.area) throw new Error('영역(area)이 비었습니다');
+        if (!cfg.area) {
+          res.writeHead(400, JSONH);
+          return res.end(JSON.stringify({ ok: false, error: '영역을 입력하세요.' }));
+        }
         usage.count++;
-        console.log('[generate] 영역:', cfg.area, '— claude -p 실행 중… (' + usage.count + '/' + DAILY_LIMIT + ')');
-        const raw = await runClaude(buildPrompt(cfg));
-        const report = extractReport(raw);
-        console.log('[generate] 완료');
-        res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify({ ok: true, report }));
+        const jobId = randomUUID();
+        jobs.set(jobId, { state: 'running', steps: { market: '대기', competition: '대기', regulation: '대기', synth: '대기' }, report: null, error: null, ts: Date.now() });
+        console.log('[' + jobId.slice(0, 8) + '] 시작:', cfg.area, '(' + usage.count + '/' + DAILY_LIMIT + ') — 3 리서처 병렬');
+        orchestrate(jobId, cfg); // 비동기 실행
+        res.writeHead(200, JSONH);
+        res.end(JSON.stringify({ ok: true, jobId }));
       } catch (e) {
-        console.error('[generate] 오류:', e.message);
-        res.writeHead(500, { 'content-type': 'application/json; charset=utf-8' });
+        res.writeHead(500, JSONH);
         res.end(JSON.stringify({ ok: false, error: String(e.message || e) }));
       }
     });
@@ -105,10 +178,10 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(PORT, () => {
-  console.log('\n  신사업 발굴 — 로컬 브리지');
+  console.log('\n  신사업 발굴 — 로컬 브리지 (오케스트레이터: 3 리서처 병렬 + 종합)');
   console.log('  → http://localhost:' + PORT);
-  console.log('  (Claude Code 구독 인증 + 내장 WebSearch 사용 · 종량 API 키 불필요)');
+  console.log('  (Claude Code 구독 인증 + 내장 WebSearch · 종량 API 키 불필요)');
   console.log('  접속 암호: ' + (BRIDGE_PASSWORD ? '설정됨 ✅' : '없음 ⚠️ (외부 공개 시 BRIDGE_PASSWORD 환경변수로 꼭 설정)'));
-  console.log('  일일 사용 한도: ' + (DAILY_LIMIT > 0 ? DAILY_LIMIT + '건' : '제한 없음'));
+  console.log('  일일 사용 한도: ' + (DAILY_LIMIT > 0 ? DAILY_LIMIT + '건' : '제한 없음') + ' · 1건당 claude -p 4회(병렬3+종합)');
   console.log('  사전조건: claude CLI 설치 + 구독 로그인(claude 실행 후 /login)\n');
 });


### PR DESCRIPTION
## 개요
브리지의 리서처를 **단일 패스 → 오케스트레이터(시장·경쟁·규제 3 리서처 병렬 + 종합)** 로 강화(Standard).

## 변경
- `server.mjs`: 도메인별 `claude -p` 병렬 실행 → 종합 에이전트가 REPORT JSON 생성. **비동기 작업+폴링**(`POST /generate`→`jobId`, `GET /status?id`) 도입 → 장시간 실행/터널 타임아웃 회피. 도메인별 심층 프롬프트(최소 출처수·한국 1차출처·인용 강제·생보사 진입요건).
- `public/index.html`: 진행상황(시장/경쟁/규제/종합) 폴링 표시.
- `README.md`: 새 구조·비용(1건당 claude -p 4회, 크레딧 3~4배) 반영.

## 검증
모의 claude로 병렬→종합→done 흐름 + 폴링 정상.

https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC)_