### PR TITLE
Windows spawn ENOENT 수정 (stdin 전달 + shell 경유)

### DIFF
--- a/tools/local-agent/server.mjs
+++ b/tools/local-agent/server.mjs
@@ -79,8 +79,11 @@ ${r}`;
 
 function runClaudeText(prompt) {
   return new Promise((resolve, reject) => {
-    const args = ['-p', prompt, '--output-format', 'json', '--allowedTools', 'WebSearch,WebFetch'];
-    const cp = spawn(CLAUDE_BIN, args, { cwd: __dirname });
+    // 프롬프트는 stdin으로 전달(인자 길이 한계·이스케이프 문제 회피).
+    // Windows에서는 claude가 claude.cmd 이므로 shell 경유로 실행해 ENOENT 방지.
+    const args = ['-p', '--output-format', 'json', '--allowedTools', 'WebSearch,WebFetch'];
+    const isWin = process.platform === 'win32';
+    const cp = spawn(CLAUDE_BIN, args, { cwd: __dirname, shell: isWin });
     let out = '', err = '';
     cp.stdout.on('data', d => (out += d));
     cp.stderr.on('data', d => (err += d));
@@ -91,6 +94,9 @@ function runClaudeText(prompt) {
       try { const env = JSON.parse(out); if (env && typeof env.result === 'string') text = env.result; } catch (e) {}
       resolve(text);
     });
+    cp.stdin.on('error', () => {}); // EPIPE 무시
+    cp.stdin.write(prompt);
+    cp.stdin.end();
   });
 }
 


### PR DESCRIPTION
## 문제
브라우저에서 생성 시 `spawn claude ENOENT`. Windows에선 claude가 `claude.cmd`라 Node `spawn('claude')`가 shell 없이는 못 찾음. 추가로, 프롬프트를 명령행 인자로 넘겨 종합 단계(3개 리포트 포함)가 Windows 명령행 길이(~8KB)를 초과할 위험.

## 수정
- 프롬프트를 **stdin**으로 전달(인자 길이·이스케이프 문제 회피).
- Windows에서 `spawn(..., { shell: true })`로 `claude.cmd` 정상 해석(ENOENT 해결).
- stdin EPIPE 무시.

## 검증
모의 claude로 stdin 경로 오케스트레이션 done까지 정상.

https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVVTWzEqRFCnyJL2qjbzeC)_